### PR TITLE
fix(merkle): descend using build_tree's midpoint in collect_proof

### DIFF
--- a/src/core/merkle.rs
+++ b/src/core/merkle.rs
@@ -90,21 +90,18 @@ impl MerkleTree {
     }
 
     /// Build the tree recursively - hashes RAW BYTES, not strings
+    ///
+    /// Leaves are split at `ceil(n / 2)`: the left subtree takes the extra leaf when
+    /// `n` is odd. No leaf is ever duplicated, so the tree is not vulnerable to the
+    /// CVE-2012-2459 style root collision. `collect_proof` must use this same midpoint.
     fn build_tree(hashes: &[Hash]) -> MerkleNode {
         if hashes.len() == 1 {
             return MerkleNode::Leaf { hash: hashes[0] };
         }
 
-        let mid = (hashes.len() + 1) / 2;
-        let left_hashes = &hashes[..mid];
-        let right_hashes = if mid < hashes.len() {
-            &hashes[mid..]
-        } else {
-            &hashes[mid - 1..mid] // Duplicate last if odd (STANDARDIZED)
-        };
-
-        let left = Self::build_tree(left_hashes);
-        let right = Self::build_tree(right_hashes);
+        let mid = hashes.len().div_ceil(2);
+        let left = Self::build_tree(&hashes[..mid]);
+        let right = Self::build_tree(&hashes[mid..]);
 
         // CRITICAL: Concatenate BYTES, not strings
         let mut combined = Vec::with_capacity(64);
@@ -165,7 +162,10 @@ impl MerkleTree {
         match node {
             MerkleNode::Leaf { .. } => {}
             MerkleNode::Branch { left, right, .. } => {
-                let mid = (start + end) / 2;
+                // Must mirror build_tree's ceil(n / 2) split, otherwise odd-sized
+                // subtrees descend into the wrong child and the proof authenticates
+                // a neighbouring leaf instead of the target.
+                let mid = start + (end - start).div_ceil(2);
 
                 if target_index < mid {
                     // Target is in left subtree, add right sibling
@@ -255,7 +255,7 @@ mod tests {
     fn test_single_leaf_tree() {
         let h1 = dummy_hash(1);
         let tree = MerkleTree::from_hashes_bytes(vec![h1]);
-        
+
         // Root of single leaf should be the leaf itself
         assert_eq!(tree.root_hash_bytes().unwrap(), h1);
         assert!(tree.verify_tree());
@@ -300,8 +300,44 @@ mod tests {
         let tree = MerkleTree::from_hashes_bytes(hashes.clone());
         let root = tree.root_hash_bytes().unwrap();
 
-        let proof = tree.generate_proof(&hashes[2]).unwrap();
-        assert!(proof.verify(&root));
+        // Every leaf must be provable, not just the last one.
+        for (i, h) in hashes.iter().enumerate() {
+            let proof = tree.generate_proof(h).expect("proof should generate");
+            assert!(proof.verify(&root), "proof for leaf {i} must verify");
+        }
+    }
+
+    /// `build_tree` splits at `ceil(n/2)`, so proof collection must descend using
+    /// the same midpoint. Any tree whose leaf count is not a power of two exercises
+    /// the mismatch.
+    #[test]
+    fn test_proofs_verify_for_every_leaf_count() {
+        for n in 1..=33usize {
+            let hashes: Vec<Hash> = (0..n).map(|i| dummy_hash(i as u8)).collect();
+            let tree = MerkleTree::from_hashes_bytes(hashes.clone());
+            let root = tree.root_hash_bytes().unwrap();
+
+            for (i, h) in hashes.iter().enumerate() {
+                let proof = tree
+                    .generate_proof(h)
+                    .unwrap_or_else(|| panic!("n={n}: proof for leaf {i} should generate"));
+                assert!(
+                    proof.verify(&root),
+                    "n={n}: proof for leaf {i} must verify against the root"
+                );
+            }
+        }
+    }
+
+    /// A proof built for one leaf must not verify when replayed for a different leaf.
+    #[test]
+    fn test_proof_does_not_verify_for_wrong_leaf() {
+        let hashes = vec![dummy_hash(1), dummy_hash(2), dummy_hash(3)];
+        let tree = MerkleTree::from_hashes_bytes(hashes.clone());
+        let root = tree.root_hash_bytes().unwrap();
+
+        let mut proof = tree.generate_proof(&hashes[0]).unwrap();
+        proof.tx_hash = hashes[1];
+        assert!(!proof.verify(&root), "proof must be bound to its own leaf");
     }
 }
-


### PR DESCRIPTION
## Description

`MerkleTree::generate_proof` only returns verifiable proofs when the number of leaves is an exact power of two. For every other leaf count, most leaves produce a proof that fails `MerkleProof::verify`.

`build_tree` splits leaves at `ceil(n / 2)`:

```rust
let mid = (hashes.len() + 1) / 2;   // ceil
```

but `collect_proof` descends using `floor((start + end) / 2)`:

```rust
let mid = (start + end) / 2;        // floor
```

The two disagree whenever a subtree holds an odd number of leaves. Proof collection then walks into the wrong child and emits a path that authenticates a *neighbouring* leaf rather than the requested one.

Failing leaf indices with the current code:

| leaves | indices whose proof fails to verify |
|-------:|-------------------------------------|
| 3 | 0, 1 |
| 5 | 0, 1, 2, 3 |
| 6 | 0, 1, 3, 4 |
| 7 | 0, 1, 2, 3, 4, 5 |
| 9 | 0, 1, 2, 3, 4, 5, 6, 7 |

1, 2, 4 and 8 leaves pass only because `ceil == floor` for powers of two.

The existing `test_odd_number_of_leaves` builds a 3-leaf tree but asserts only on index `2` — the one index that happens to survive the mismatch — which is why this went unnoticed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Motivation and Context

`generate_proof` / `MerkleProof` are the SPV surface of the `quanta` library. Any light client built on them would reject valid inclusion proofs for essentially every real block, since blocks rarely contain exactly 2^k transactions.

**This is not a consensus issue.** Merkle *roots* are computed by `build_tree`, which is internally self-consistent and used identically by `Block::new`, `Block::validate` and `Blockchain`. Only proof *generation* is wrong. I verified roots are byte-identical before and after this change for n = 1..=9, so block validation and chain state are untouched.

## How Has This Been Tested?

- Confirmed the three new/updated tests **fail on `main`** and pass with the fix.
- `cargo test --lib` → **94 passed, 0 failed** (existing block/genesis/consensus tests unchanged).
- Verified merkle roots are unchanged: printed `root_hash()` for n = 1..=9 with and without the patch, diffed, identical.
- `cargo clippy --lib` and `cargo fmt --check` are clean for `src/core/merkle.rs`.

New coverage:

- `test_proofs_verify_for_every_leaf_count` — every leaf index for every leaf count `1..=33`.
- `test_proof_does_not_verify_for_wrong_leaf` — a proof cannot be replayed against a different leaf. (This one is a direct regression guard: on `main` the proof generated for leaf 0 of a 3-leaf tree actually verifies leaf 1.)
- `test_odd_number_of_leaves` — now asserts on all three leaves, not just the last.

## Secondary cleanup

`build_tree`'s `else` branch was unreachable dead code:

```rust
let right_hashes = if mid < hashes.len() {
    &hashes[mid..]
} else {
    &hashes[mid - 1..mid]   // "Duplicate last if odd (STANDARDIZED)"
};
```

`mid = ceil(len/2) < len` holds for every `len >= 2`, and `len == 1` returns early, so the duplicate-last path never executed and no leaf was ever duplicated. I removed it and documented the actual invariant. Worth noting this is a *good* property: because leaves are never duplicated, the tree is not susceptible to the CVE-2012-2459 style root collision. The old comment implied the opposite scheme.

## Note for maintainers (not addressed here, happy to file separately)

`hash_to_bytes` will panic on malformed input — `hex::decode(...).expect("Invalid hex hash")` and `copy_from_slice(&bytes[..32])` on a short slice. It is reachable from the public `generate_proof_hex` and `verify_hex`. Internal callers always pass well-formed 64-char hashes so nothing panics today, but returning `Option<Hash>` would harden the public API. I kept this PR focused rather than folding that in.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] All tests pass (`cargo test`)
- [x] Documentation is updated (doc comments on `build_tree` / `collect_proof`)
